### PR TITLE
Add project keys filter for ticket schemas limit to 100 schemas

### DIFF
--- a/cmd/baton-jira-datacenter/config.go
+++ b/cmd/baton-jira-datacenter/config.go
@@ -7,7 +7,7 @@ import (
 var (
 	instanceURLField = field.StringField("instance-url", field.WithRequired(true), field.WithDescription(`The URL that Jira is hosted at. Example: "https://localhost:8080"`))
 	accessTokenField = field.StringField("access-token", field.WithRequired(true), field.WithDescription("The Jira personal access token to authenticate with."))
-	projectKeysField = field.StringSliceField("project-keys", field.WithDescription("The Jira project keys to filter for external ticket provisioning."))
+	projectKeysField = field.StringSliceField("project-keys", field.WithDescription("Limit external ticket schemas to any of the provided project keys"))
 )
 
 // configurationFields defines the external configuration required for the connector to run.

--- a/cmd/baton-jira-datacenter/config.go
+++ b/cmd/baton-jira-datacenter/config.go
@@ -7,10 +7,16 @@ import (
 var (
 	instanceURLField = field.StringField("instance-url", field.WithRequired(true), field.WithDescription(`The URL that Jira is hosted at. Example: "https://localhost:8080"`))
 	accessTokenField = field.StringField("access-token", field.WithRequired(true), field.WithDescription("The Jira personal access token to authenticate with."))
+	projectKeysField = field.StringSliceField("project-keys", field.WithDescription("The Jira project keys to filter for external ticket provisioning."))
 )
 
 // configurationFields defines the external configuration required for the connector to run.
 var configurationFields = []field.SchemaField{
 	instanceURLField,
 	accessTokenField,
+	projectKeysField,
+}
+
+var configRelations = []field.SchemaFieldRelationship{
+	field.FieldsDependentOn([]field.SchemaField{projectKeysField}, []field.SchemaField{field.TicketingField}),
 }

--- a/cmd/baton-jira-datacenter/main.go
+++ b/cmd/baton-jira-datacenter/main.go
@@ -21,7 +21,7 @@ var version = "dev"
 func main() {
 	ctx := context.Background()
 
-	_, cmd, err := configschema.DefineConfiguration(ctx, "baton-jira-datacenter", getConnector, field.NewConfiguration(configurationFields))
+	_, cmd, err := configschema.DefineConfiguration(ctx, "baton-jira-datacenter", getConnector, field.NewConfiguration(configurationFields, configRelations...))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
@@ -38,7 +38,7 @@ func main() {
 
 func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, error) {
 	l := ctxzap.Extract(ctx)
-	cb, err := connector.New(ctx, v.GetString(instanceURLField.FieldName), v.GetString(accessTokenField.FieldName))
+	cb, err := connector.New(ctx, v.GetString(instanceURLField.FieldName), v.GetString(accessTokenField.FieldName), v.GetStringSlice(projectKeysField.FieldName))
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/andygrunwald/go-jira/v2 v2.0.0-20240419124508-6752705de4c7
-	github.com/conductorone/baton-sdk v0.2.12
+	github.com/conductorone/baton-sdk v0.2.13
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/protobuf v1.34.1

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/conductorone/baton-sdk v0.2.12 h1:u5tbqpSgk/hTsZ8auwEQFqS8UxprK9k8yuJddY8hsfE=
-github.com/conductorone/baton-sdk v0.2.12/go.mod h1:cg5FyUcJnD7xK5SPbHe/KNpwUVVlpHJ9rnmd3UwxSkU=
+github.com/conductorone/baton-sdk v0.2.13 h1:/9wJGlbiPxDQmjqKOTqyKpJ1Ui2+o7oYHInMqqR1PyQ=
+github.com/conductorone/baton-sdk v0.2.13/go.mod h1:cg5FyUcJnD7xK5SPbHe/KNpwUVVlpHJ9rnmd3UwxSkU=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -15,6 +15,7 @@ type Connector struct {
 	jiraClient     *client.Client
 	ticketSchemas  map[string]*v2.TicketSchema
 	ticketStatuses []*v2.TicketStatus
+	projectKeys    []string
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
@@ -49,7 +50,7 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, instanceURL, accessToken string) (*Connector, error) {
+func New(ctx context.Context, instanceURL, accessToken string, projectKeys []string) (*Connector, error) {
 	jiraClient, err := client.New(ctx, instanceURL, accessToken)
 	if err != nil {
 		return nil, err
@@ -58,6 +59,7 @@ func New(ctx context.Context, instanceURL, accessToken string) (*Connector, erro
 	c := &Connector{
 		jiraClient:    jiraClient,
 		ticketSchemas: make(map[string]*v2.TicketSchema),
+		projectKeys:   projectKeys,
 	}
 
 	return c, nil

--- a/pkg/connector/tickets.go
+++ b/pkg/connector/tickets.go
@@ -38,13 +38,13 @@ func (d *Connector) ListTicketSchemas(ctx context.Context, pToken *pagination.To
 	}
 
 	for _, project := range projects {
+		if len(ret) == maxProjects {
+			break
+		}
 		if shouldFilterByProjectKey {
 			if _, ok := projectKeyMap[project.Key]; !ok {
 				continue
 			}
-		}
-		if len(ret) == maxProjects {
-			break
 		}
 		schema, err := d.schemaForProject(ctx, project)
 		if err != nil {

--- a/vendor/github.com/conductorone/baton-sdk/pkg/config/config.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/config/config.go
@@ -96,7 +96,7 @@ func DefineConfiguration(
 			mainCMD.PersistentFlags().
 				StringP(field.FieldName, field.CLIShortHand, value, field.GetDescription())
 		case reflect.Slice:
-			value, err := field.StringArray()
+			value, err := field.StringSlice()
 			if err != nil {
 				return nil, nil, fmt.Errorf(
 					"field %s, %s: %w",
@@ -106,7 +106,7 @@ func DefineConfiguration(
 				)
 			}
 			mainCMD.PersistentFlags().
-				StringArrayP(field.FieldName, field.CLIShortHand, value, field.GetDescription())
+				StringSliceP(field.FieldName, field.CLIShortHand, value, field.GetDescription())
 		default:
 			return nil, nil, fmt.Errorf(
 				"field %s, %s is not yet supported",

--- a/vendor/github.com/conductorone/baton-sdk/pkg/field/fields.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/field/fields.go
@@ -51,8 +51,8 @@ func (s SchemaField) String() (string, error) {
 	return value, nil
 }
 
-// StringArray retuns the default value as a string array.
-func (s SchemaField) StringArray() ([]string, error) {
+// StringSlice retuns the default value as a string array.
+func (s SchemaField) StringSlice() ([]string, error) {
 	value, ok := s.DefaultValue.([]string)
 	if !ok {
 		return nil, WrongValueTypeErr
@@ -130,7 +130,7 @@ func IntField(name string, optional ...fieldOption) SchemaField {
 	return field
 }
 
-func StringArrayField(name string, optional ...fieldOption) SchemaField {
+func StringSliceField(name string, optional ...fieldOption) SchemaField {
 	field := SchemaField{
 		FieldName:    name,
 		FieldType:    reflect.Slice,

--- a/vendor/github.com/conductorone/baton-sdk/pkg/field/validation.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/field/validation.go
@@ -49,7 +49,7 @@ func Validate(c Configuration, v *viper.Viper) error {
 		case reflect.String:
 			isNonZero = v.GetString(f.FieldName) != ""
 		case reflect.Slice:
-			isNonZero = len(v.GetStringSlice(f.FieldName)) == 0
+			isNonZero = len(v.GetStringSlice(f.FieldName)) != 0
 		default:
 			return fmt.Errorf("field %s has unsupported type %s", f.FieldName, f.FieldType)
 		}

--- a/vendor/github.com/conductorone/baton-sdk/pkg/sdk/version.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/sdk/version.go
@@ -1,3 +1,3 @@
 package sdk
 
-const Version = "v0.2.10-15-gfd76fb6"
+const Version = "v0.2.12"

--- a/vendor/github.com/conductorone/baton-sdk/pkg/tasks/c1api/list_ticket_schemas.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/tasks/c1api/list_ticket_schemas.go
@@ -15,6 +15,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types"
 )
 
+const maxTicketSchemas = 100
+
 type listTicketSchemasTaskHelpers interface {
 	ConnectorClient() types.ConnectorClient
 	FinishTask(ctx context.Context, resp proto.Message, annos annotations.Annotations, err error) error
@@ -48,9 +50,22 @@ func (c *listTicketSchemasTaskHandler) HandleTask(ctx context.Context) error {
 
 		ticketSchemas = append(ticketSchemas, schemas.GetList()...)
 
+		// Only return first 100 elements
+		if len(ticketSchemas) >= maxTicketSchemas {
+			ignoreCount := len(ticketSchemas) - maxTicketSchemas
+			ticketSchemas = ticketSchemas[:maxTicketSchemas]
+			hasAdditionalPages := schemas.GetNextPageToken() != ""
+
+			l.Info("list ticket schemas was greater than or equal to max of 100",
+				zap.Int("ignoredCount", ignoreCount),
+				zap.Bool("hasAdditionalPages", hasAdditionalPages))
+			break
+		}
+
 		if schemas.GetNextPageToken() == "" {
 			break
 		}
+
 		pageToken = schemas.GetNextPageToken()
 	}
 

--- a/vendor/github.com/conductorone/baton-sdk/pkg/uhttp/wrapper.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/uhttp/wrapper.go
@@ -16,7 +16,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const ContentType = "Content-Type"
+const (
+	ContentType               = "Content-Type"
+	applicationJSON           = "application/json"
+	applicationXML            = "application/xml"
+	applicationFormUrlencoded = "application/x-www-form-urlencoded"
+	applicationVndApiJSON     = "application/vnd.api+json"
+	acceptHeader              = "Accept"
+)
 
 type WrapperResponse struct {
 	Header     http.Header
@@ -203,16 +210,53 @@ func WithJSONBody(body interface{}) RequestOption {
 	}
 }
 
+func WithFormBody(body string) RequestOption {
+	return func() (io.ReadWriter, map[string]string, error) {
+		var buffer bytes.Buffer
+		_, err := buffer.WriteString(body)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		_, headers, err := WithContentTypeFormHeader()()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &buffer, headers, nil
+	}
+}
+
 func WithAcceptJSONHeader() RequestOption {
-	return WithHeader("Accept", "application/json")
+	return WithAccept(applicationJSON)
 }
 
 func WithContentTypeJSONHeader() RequestOption {
-	return WithHeader("Content-Type", "application/json")
+	return WithContentType(applicationJSON)
 }
 
 func WithAcceptXMLHeader() RequestOption {
-	return WithHeader("Accept", "application/xml")
+	return WithAccept(applicationXML)
+}
+
+func WithContentTypeFormHeader() RequestOption {
+	return WithContentType(applicationFormUrlencoded)
+}
+
+func WithContentTypeVndHeader() RequestOption {
+	return WithContentType(applicationVndApiJSON)
+}
+
+func WithAcceptVndJSONHeader() RequestOption {
+	return WithAccept(applicationVndApiJSON)
+}
+
+func WithContentType(ctype string) RequestOption {
+	return WithHeader(ContentType, ctype)
+}
+
+func WithAccept(value string) RequestOption {
+	return WithHeader(acceptHeader, value)
 }
 
 func (c *BaseHttpClient) NewRequest(ctx context.Context, method string, url *url.URL, options ...RequestOption) (*http.Request, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -143,7 +143,7 @@ github.com/aws/smithy-go/waiter
 # github.com/benbjohnson/clock v1.3.5
 ## explicit; go 1.15
 github.com/benbjohnson/clock
-# github.com/conductorone/baton-sdk v0.2.12
+# github.com/conductorone/baton-sdk v0.2.13
 ## explicit; go 1.21
 github.com/conductorone/baton-sdk/internal/connector
 github.com/conductorone/baton-sdk/pb/c1/c1z/v1


### PR DESCRIPTION
# Pull Request

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [x] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the Connector in any way?

* [ ] Yes (backward compatible)
* [ ] No (breaking changes)

#### Useful links:

- [https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines](Baton SDK coding guidelines)
- [https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md](New contributor guide)

## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- Add project keys filter for ticket schemas
-  Limit to 100 schemas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced project key filtering for ticket schemas, enhancing usability and performance.
	- Added support for multiple project keys in the connector for improved resource management.

- **Bug Fixes**
	- Updated dependency on the baton-sdk to the latest version, potentially resolving previous issues and enhancing performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->