### PR TITLE
Do not add a custom field for empty string values

### DIFF
--- a/pkg/connector/tickets.go
+++ b/pkg/connector/tickets.go
@@ -52,6 +52,9 @@ func (d *Connector) customFieldSchemaToMetaField(field *v2.TicketCustomField) (i
 				return v, nil
 			}
 		}
+		if len(strValue) == 0 {
+			return nil, nil
+		}
 		return strValue, nil
 
 	case *v2.TicketCustomField_StringValues:
@@ -444,6 +447,7 @@ func (d *Connector) GetTicket(ctx context.Context, ticketId string) (*v2.Ticket,
 
 // This is returning nil for annotations.
 func (d *Connector) CreateTicket(ctx context.Context, ticket *v2.Ticket, schema *v2.TicketSchema) (*v2.Ticket, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
 	ticketOptions := []client.FieldOption{
 		client.WithStatus(ticket.GetStatus().GetId()),
 		client.WithDescription(ticket.GetDescription()),
@@ -499,6 +503,7 @@ func (d *Connector) CreateTicket(ctx context.Context, ticket *v2.Ticket, schema 
 				continue
 			}
 
+			l.Info("adding custom field to new ticket", zap.String("id", id), zap.Any("value", metaFieldValue))
 			ticketOptions = append(ticketOptions, client.WithCustomField(cf.GetId(), metaFieldValue))
 		}
 	}


### PR DESCRIPTION
# Pull Request

This change will exclude custom fields in the create ticket request to Jira Datacenter's API when their value is an empty string. The reason for this is because we will include empty strings for all string fields in a ticket schema in every create ticket request when they don't have a value configured in the payload.

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the Connector in any way?

* [ ] Yes (backward compatible)
* [x] No (breaking changes)

#### Useful links:

- [https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines](Baton SDK coding guidelines)
- [https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md](New contributor guide)

## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- Exclude custom fields when they are string fields with empty strings as values
- Log all custom fields sent as part of a create ticket task


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of empty custom field values during ticket creation.
	- Improved logging for custom fields added to new tickets, providing better traceability.

- **Bug Fixes**
	- Ensured that empty string values are correctly processed as `nil` to improve functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->