### PR TITLE
BB-285 fix truncated user list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,6 @@ linters:
     - durationcheck # check for two durations multiplied together
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
     - exhaustive # check exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # Forbids identifiers
     - gochecknoinits # Checks that no init functions are present in Go code
     - goconst # Finds repeated strings that could be replaced by a constant

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Flags:
       --access-token string    required: The Jira personal access token to authenticate with. ($BATON_ACCESS_TOKEN)
       --client-id string       The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
       --client-secret string   The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
+      --default-group-name     The default group name (jira-software-users by default)
   -f, --file string            The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")
   -h, --help                   help for baton-jira-datacenter
       --instance-url string    required: The URL that Jira is hosted at. Example: "https://localhost:8080" ($BATON_INSTANCE_URL)

--- a/cmd/baton-jira-datacenter/config.go
+++ b/cmd/baton-jira-datacenter/config.go
@@ -8,6 +8,7 @@ var (
 	instanceURLField = field.StringField("instance-url", field.WithRequired(true), field.WithDescription(`The URL that Jira is hosted at. Example: "https://localhost:8080"`))
 	accessTokenField = field.StringField("access-token", field.WithRequired(true), field.WithDescription("The Jira personal access token to authenticate with."))
 	projectKeysField = field.StringSliceField("project-keys", field.WithDescription("Limit external ticket schemas to any of the provided project keys"))
+	defaultGroupName = field.StringField("default-group-name", field.WithDefaultValue("jira-software-users"), field.WithDescription("The default group name for new users"))
 )
 
 // configurationFields defines the external configuration fields necessary for the Jira Datacenter connector to
@@ -16,6 +17,7 @@ var configurationFields = []field.SchemaField{
 	instanceURLField,
 	accessTokenField,
 	projectKeysField,
+	defaultGroupName,
 }
 
 var configRelations = []field.SchemaFieldRelationship{

--- a/cmd/baton-jira-datacenter/main.go
+++ b/cmd/baton-jira-datacenter/main.go
@@ -38,7 +38,12 @@ func main() {
 
 func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, error) {
 	l := ctxzap.Extract(ctx)
-	cb, err := connector.New(ctx, v.GetString(instanceURLField.FieldName), v.GetString(accessTokenField.FieldName), v.GetStringSlice(projectKeysField.FieldName))
+	cb, err := connector.New(ctx,
+		v.GetString(instanceURLField.FieldName),
+		v.GetString(accessTokenField.FieldName),
+		v.GetStringSlice(projectKeysField.FieldName),
+		v.GetString(defaultGroupName.FieldName),
+	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/client/internal_test.go
+++ b/pkg/client/internal_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 var (
-	ctx            = context.Background()
-	instanceUrl, _ = os.LookupEnv("BATON_INSTANCE_URL")
-	accessToken, _ = os.LookupEnv("BATON_ACCESS_TOKEN")
+	ctx              = context.Background()
+	instanceUrl, _   = os.LookupEnv("BATON_INSTANCE_URL")
+	accessToken, _   = os.LookupEnv("BATON_ACCESS_TOKEN")
+	defaultGroupName = "jira-software-users"
 )
 
 func TestClientListAllPermissions(t *testing.T) {
@@ -20,7 +21,7 @@ func TestClientListAllPermissions(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	permissions, err := client.ListAllPermissions(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, permissions)
@@ -31,7 +32,7 @@ func TestClientListAllUsers(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	roles, err := client.ListAllUsers(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, roles)
@@ -42,7 +43,7 @@ func TestClientListAllGroups(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	roles, err := client.ListAllGroups(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, roles)
@@ -75,7 +76,7 @@ func TestClientGetGroupMembers(t *testing.T) {
 		},
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			roles, err := client.GetGroupMembers(ctx, test.groupName)
@@ -90,7 +91,7 @@ func TestClientListAllRoles(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	roles, err := client.ListAllRoles(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, roles)
@@ -101,7 +102,7 @@ func TestClientGetUser(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	user, err := client.GetUser(ctx, "globaluser")
 	assert.Nil(t, err)
 	assert.NotNil(t, user)
@@ -112,7 +113,7 @@ func TestClientGetProjectRoles(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	roleList, err := client.GetProjectRoles(ctx, "10000")
 	assert.Nil(t, err)
 	assert.NotNil(t, roleList)
@@ -137,7 +138,7 @@ func TestClientGetProjectRoleDetails(t *testing.T) {
 		},
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			roles, err := client.GetProjectRoleDetails(ctx, test.url)
@@ -165,7 +166,7 @@ func TestClientGetRole(t *testing.T) {
 			roleId: "10100",
 		},
 	}
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			roles, err := client.GetRole(ctx, test.roleId)
@@ -180,7 +181,7 @@ func TestClientGetGroupRole(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	roleByGroups, err := client.GetGroupRole(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, roleByGroups)
@@ -191,7 +192,7 @@ func TestClientGetGroupRoles(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	roles, err := client.GetGroupLabelRoles(ctx, "global-group")
 	assert.Nil(t, err)
 	assert.NotNil(t, roles)
@@ -202,7 +203,7 @@ func TestClientListAllPermissionScheme(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	permissionList, err := client.ListAllPermissionScheme(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, permissionList)
@@ -213,7 +214,7 @@ func TestClientAddActorsToProjectRole(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	body := BodyActors{
 		Group: []string{
 			"jira-software-users",
@@ -229,7 +230,7 @@ func TestClientRemoveActorsFromProjectRole(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	statusCode, err := client.RemoveActorsFromProjectRole(ctx, "10000", "10002", "group", "jira-administrators")
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusNoContent, statusCode)
@@ -240,7 +241,7 @@ func TestClientAddUserToGroupFails(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	userName, err := client.GetUserName(ctx, "JIRAUSER10103")
 	assert.Nil(t, err)
 
@@ -253,7 +254,7 @@ func TestClientAddUserToGroup(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	userName, err := client.GetUserName(ctx, "JIRAUSER10103")
 	assert.Nil(t, err)
 
@@ -267,7 +268,7 @@ func TestClientRemoveUserFromGroup(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	userName, err := client.GetUserName(ctx, "JIRAUSER10103")
 	assert.Nil(t, err)
 
@@ -281,7 +282,7 @@ func TestClientAddProjectRoleActorsToRoleWithGroup(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	actors, err := client.AddProjectRoleActorsToRole(ctx, "10002", BodyActors{
 		Group: []string{
 			"jira-software-users",
@@ -296,7 +297,7 @@ func TestClientAddProjectRoleActorsToRoleWithUser(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	actors, err := client.AddProjectRoleActorsToRole(ctx, "10002", BodyActors{
 		User: []string{
 			"JIRAUSER10103",
@@ -311,7 +312,7 @@ func TestClientDeleteProjectRoleActorsFromRoleWithGroup(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	statusCode, err := client.DeleteProjectRoleActorsFromRole(ctx, "10002", "group", "jira-software-users")
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -322,7 +323,7 @@ func TestClientDeleteProjectRoleActorsFromRoleWithUser(t *testing.T) {
 		t.Skip()
 	}
 
-	client, _ := New(ctx, instanceUrl, accessToken)
+	client, _ := New(ctx, instanceUrl, accessToken, defaultGroupName)
 	statusCode, err := client.DeleteProjectRoleActorsFromRole(ctx, "10002", "user", "JIRAUSER10102")
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, statusCode)

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -50,8 +50,8 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, instanceURL, accessToken string, projectKeys []string) (*Connector, error) {
-	jiraClient, err := client.New(ctx, instanceURL, accessToken)
+func New(ctx context.Context, instanceURL, accessToken string, projectKeys []string, defaultGroupName string) (*Connector, error) {
+	jiraClient, err := client.New(ctx, instanceURL, accessToken, defaultGroupName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/internal_integration_test.go
+++ b/pkg/connector/internal_integration_test.go
@@ -24,6 +24,7 @@ var (
 	parentResourceID       = &v2.ResourceId{}
 	pToken                 = &pagination.Token{}
 	grantPrincipalTypeUser = "user"
+	defaultGroupName       = "jira-software-users"
 )
 
 func TestGroupBuilderList(t *testing.T) {
@@ -31,7 +32,7 @@ func TestGroupBuilderList(t *testing.T) {
 		t.Skip()
 	}
 
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	g := &groupBuilder{
 		client: cli,
 	}
@@ -45,7 +46,7 @@ func TestProjectBuilderList(t *testing.T) {
 		t.Skip()
 	}
 
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	p := &projectBuilder{
 		client: cli,
 	}
@@ -59,7 +60,7 @@ func TestUserBuilderList(t *testing.T) {
 		t.Skip()
 	}
 
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	u := &userBuilder{
 		client: cli,
 	}
@@ -73,7 +74,7 @@ func TestRoleBuilderList(t *testing.T) {
 		t.Skip()
 	}
 
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	r := &roleBuilder{
 		client: cli,
 	}
@@ -88,7 +89,7 @@ func TestProjectBuilderGrants(t *testing.T) {
 	}
 
 	pToken := &pagination.Token{}
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	p := &projectBuilder{
 		client: cli,
 	}
@@ -167,7 +168,7 @@ func TestGroupBuilderEntitlements(t *testing.T) {
 	}
 
 	pToken := &pagination.Token{}
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	g := &groupBuilder{
 		client: cli,
 	}
@@ -222,7 +223,7 @@ func TestProjectBuilderGrantGroup(t *testing.T) {
 	assert.Nil(t, err)
 
 	entitlement := getEntitlementForTesting(resource, grantPrincipalType, roleEntitlement)
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	projectBuilder := getProjectBuilderForTesting(cli)
 	_, err = projectBuilder.Grant(ctx, principal, entitlement)
 	assert.Nil(t, err)
@@ -256,7 +257,7 @@ func TestProjectBuilderGrantUsers(t *testing.T) {
 	assert.Nil(t, err)
 
 	entitlement := getEntitlementForTesting(resource, grantPrincipalType, roleEntitlement)
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	projectBuilder := getProjectBuilderForTesting(cli)
 	_, err = projectBuilder.Grant(ctx, principal, entitlement)
 	assert.Nil(t, err)
@@ -290,7 +291,7 @@ func TestProjectBuilderRevokeGroup(t *testing.T) {
 	resource, err := projectResource(ctx, *project, nil)
 	assert.Nil(t, err)
 
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	projectBuilder := getProjectBuilderForTesting(cli)
 	gr := grant.NewGrant(resource, roleId, principal.Id)
 	annos := annotations.Annotations(gr.Annotations)
@@ -331,7 +332,7 @@ func TestProjectBuilderRevokeUser(t *testing.T) {
 	resource, err := projectResource(ctx, *project, nil)
 	assert.Nil(t, err)
 
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	projectBuilder := getProjectBuilderForTesting(cli)
 	gr := grant.NewGrant(resource, roleId, principal.Id)
 	annos := annotations.Annotations(gr.Annotations)
@@ -372,7 +373,7 @@ func TestGroupBuilderGrantUser(t *testing.T) {
 	assert.Nil(t, err)
 
 	entitlement := getEntitlementForTesting(resource, grantPrincipalType, roleEntitlement)
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	groupBuilder := getGroupBuilderForTesting(cli)
 	_, err = groupBuilder.Grant(ctx, principal, entitlement)
 	assert.Nil(t, err)
@@ -406,7 +407,7 @@ func TestGroupBuilderRevokeUser(t *testing.T) {
 	resource, err := groupResource(ctx, *group, nil)
 	assert.Nil(t, err)
 
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	groupBuilder := getGroupBuilderForTesting(cli)
 	gr := grant.NewGrant(resource, roleId, principal.Id)
 	annos := annotations.Annotations(gr.Annotations)
@@ -504,7 +505,7 @@ func TestRoleBuilderGrantGroup(t *testing.T) {
 	assert.Nil(t, err)
 
 	entitlement := getEntitlementForTesting(resource, grantPrincipalType, roleEntitlement)
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	roleBuilder := getRoleBuilderForTesting(cli)
 	_, err = roleBuilder.Grant(ctx, principal, entitlement)
 	assert.Nil(t, err)
@@ -538,7 +539,7 @@ func TestRoleBuilderGrantUsers(t *testing.T) {
 	assert.Nil(t, err)
 
 	entitlement := getEntitlementForTesting(resource, grantPrincipalType, roleEntitlement)
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	roleBuilder := getRoleBuilderForTesting(cli)
 	_, err = roleBuilder.Grant(ctx, principal, entitlement)
 	assert.Nil(t, err)
@@ -572,7 +573,7 @@ func TestRoleBuilderRevokeGroup(t *testing.T) {
 	resource, err := roleResource(ctx, *role, nil)
 	assert.Nil(t, err)
 
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	roleBuilder := getRoleBuilderForTesting(cli)
 	gr := grant.NewGrant(resource, roleId, principal.Id)
 	annos := annotations.Annotations(gr.Annotations)
@@ -613,7 +614,7 @@ func TestRoleBuilderRevokeUser(t *testing.T) {
 	resource, err := roleResource(ctx, *role, nil)
 	assert.Nil(t, err)
 
-	cli, _ := client.New(ctx, instanceUrl, accessToken)
+	cli, _ := client.New(ctx, instanceUrl, accessToken, defaultGroupName)
 	roleBuilder := getRoleBuilderForTesting(cli)
 	gr := grant.NewGrant(resource, roleId, principal.Id)
 	annos := annotations.Annotations(gr.Annotations)


### PR DESCRIPTION
# Pull Request
Fixes truncated users list issue

## PR Type
What kind of change does this PR introduce?

* [ x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the Connector in any way?

* [ x] Yes (backward compatible)
* [ ] No (breaking changes)

(As long as the default group is not changed, no new actions are needed. Otherwise, a NEW flag was added to set proper group name)

#### Useful links:

- [https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines](Baton SDK coding guidelines)
- [https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md](New contributor guide)

## Issue Linking
[fixes]#BB-285

## What's new?
-
Fixed truncated user list result. When listing users, results were truncated to 1000, now we look for users by listing the members of the default jira group. By default, the group name is jira-users, optionally, a different group name can be set to retrieve the users from by setting the --default-group-name <groupname> flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable default group setting for user operations, ensuring that user listings are consistently based on a preset group.
  - Improved performance by implementing paginated retrieval for handling large user groups.
  - Updated integrations to support the new default group configuration for a more consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->