### PR TITLE
Use pick multiple object values custom field type for components

### DIFF
--- a/pkg/connector/tickets.go
+++ b/pkg/connector/tickets.go
@@ -284,7 +284,11 @@ func (d *Connector) getCustomFieldsForIssueType(ctx context.Context, projectId s
 			case !isMultiSelect && hasAllowedValues:
 				customField = sdkTicket.PickObjectValueFieldSchema(id, field.Name, field.Required, allowedValues)
 			case isMultiSelect && !hasAllowedValues:
-				customField = sdkTicket.StringsFieldSchema(id, field.Name, field.Required)
+				if field.Schema.Items == "component" {
+					customField = sdkTicket.PickMultipleObjectValuesFieldSchema(id, field.Name, field.Required, allowedValues)
+				} else {
+					customField = sdkTicket.StringsFieldSchema(id, field.Name, field.Required)
+				}
 			default:
 				customField = sdkTicket.StringFieldSchema(id, field.Name, field.Required)
 			}
@@ -490,20 +494,6 @@ func (d *Connector) CreateTicket(ctx context.Context, ticket *v2.Ticket, schema 
 
 	for id, cf := range schema.GetCustomFields() {
 		switch id {
-		case "components":
-			comps, err := sdkTicket.GetPickMultipleObjectValues(ticketFields[id])
-			if err != nil {
-				if errors.Is(err, sdkTicket.ErrFieldNil) {
-					continue
-				}
-				return nil, nil, err
-			}
-
-			componentIDs := make([]string, 0, len(comps))
-			for _, component := range comps {
-				componentIDs = append(componentIDs, component.GetId())
-			}
-			ticketOptions = append(ticketOptions, client.WithComponents(componentIDs...))
 		case "issue_type":
 			// If issueTypeID is empty, the config has not been updated to use issue type as schema
 			// So issue type is still stored in the custom fields


### PR DESCRIPTION
# Pull Request

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the Connector in any way?

* [ ] Yes (backward compatible)
* [ ] No (breaking changes)

#### Useful links:

- [https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines](Baton SDK coding guidelines)
- [https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md](New contributor guide)

## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- Use pick multiple object values for component when there are no values and don't treat components case differently than other field types


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of multi-select custom fields representing components, ensuring they are processed correctly in forms and ticket creation.
- **Refactor**
	- Updated logic for processing component fields to provide more accurate field representation and streamlined ticket creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->