### PR TITLE
[BB-543] Implement user provisioning for Jira Datacenter

### DIFF
--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -129,6 +129,14 @@ type BodyActors struct {
 	Name  string   `json:"name,omitempty"`
 }
 
+type CreateUserRequest struct {
+	Name         string `json:"name"`
+	Password     string `json:"password"`
+	EmailAddress string `json:"emailAddress"`
+	DisplayName  string `json:"displayName"`
+	Notification bool   `json:"notification,string"`
+}
+
 type ActorsAPIData struct {
 	Self        string   `json:"self,omitempty"`
 	Name        string   `json:"name,omitempty"`

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -40,6 +40,40 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 	return &v2.ConnectorMetadata{
 		DisplayName: "Jira (Datacenter)",
 		Description: "Implements syncing, provisioning, and ticketing for Jira Datacenter instances",
+		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
+			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
+				"email": {
+					DisplayName: "Email",
+					Required:    true,
+					Description: "User's email address (used for login)",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "user@example.com",
+					Order:       1,
+				},
+				"first_name": {
+					DisplayName: "First Name",
+					Required:    true,
+					Description: "User's first name",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "John",
+					Order:       2,
+				},
+				"last_name": {
+					DisplayName: "Last Name",
+					Required:    true,
+					Description: "User's last name",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "Doe",
+					Order:       3,
+				},
+			},
+		},
 	}, nil
 }
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -2,14 +2,19 @@ package connector
 
 import (
 	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
 
+	"github.com/conductorone/baton-jira-datacenter/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	sdkResource "github.com/conductorone/baton-sdk/pkg/types/resource"
 	jira "github.com/conductorone/go-jira/v2/onpremise"
-
-	"github.com/conductorone/baton-jira-datacenter/pkg/client"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 type userBuilder struct {
@@ -104,4 +109,147 @@ func newUserBuilder(client *client.Client) *userBuilder {
 	return &userBuilder{
 		client: client,
 	}
+}
+
+// CreateAccountCapabilityDetails defines what credential options are supported by this connector.
+func (u *userBuilder) CreateAccountCapabilityDetails(ctx context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
+	return &v2.CredentialDetailsAccountProvisioning{
+		SupportedCredentialOptions: []v2.CapabilityDetailCredentialOption{
+			v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_RANDOM_PASSWORD,
+		},
+		PreferredCredentialOption: v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_RANDOM_PASSWORD,
+	}, nil, nil
+}
+
+// generateRandomPassword creates a secure random password for new user accounts.
+func generateRandomPassword(length int) (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]"
+	if length < 8 {
+		length = 8 // Jira typically requires at least 8 characters
+	}
+
+	password := make([]byte, length)
+	for i := 0; i < length; i++ {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			return "", err
+		}
+		password[i] = charset[n.Int64()]
+	}
+
+	return string(password), nil
+}
+
+// CreateAccount provisions a new user in Jira Datacenter.
+func (u *userBuilder) CreateAccount(
+	ctx context.Context,
+	accountInfo *v2.AccountInfo,
+	credentialOptions *v2.CredentialOptions,
+) (connectorbuilder.CreateAccountResponse, []*v2.PlaintextData, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+
+	// Extract account information from the profile
+	profile := accountInfo.Profile.AsMap()
+
+	// Get required fields
+	email, ok := profile["email"].(string)
+	if !ok || email == "" {
+		return nil, nil, nil, fmt.Errorf("email is required")
+	}
+
+	firstName, _ := profile["first_name"].(string)
+	lastName, _ := profile["last_name"].(string)
+
+	// Create a display name from the first and last name
+	displayName := firstName
+	if lastName != "" {
+		displayName += " " + lastName
+	}
+
+	// If display name is empty, use email as display name
+	if displayName == "" {
+		displayName = email
+	}
+
+	// Generate username from email (common practice in Jira)
+	username := email
+
+	// Generate a password if needed
+	var password string
+	var plaintextData []*v2.PlaintextData
+
+	if credentialOptions.GetRandomPassword() != nil {
+		// Generate a random password
+		length := int(credentialOptions.GetRandomPassword().GetLength())
+		if length <= 0 {
+			length = 12 // Default length
+		}
+
+		var err error
+		password, err = generateRandomPassword(length)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to generate password: %w", err)
+		}
+
+		// Return the password as plaintext data
+		plaintextData = append(plaintextData, &v2.PlaintextData{
+			Name:        "password",
+			Description: "Generated password for the new account",
+			Bytes:       []byte(password),
+		})
+	} else {
+		return nil, nil, nil, fmt.Errorf("random password is required for Jira user creation")
+	}
+
+	// Create the user request
+	userRequest := &client.CreateUserRequest{
+		Name:         username,
+		Password:     password,
+		EmailAddress: email,
+		DisplayName:  displayName,
+		Notification: false, // Set to false to avoid sending notification emails
+	}
+
+	// Call the API to create the user
+	user, err := u.client.CreateUser(ctx, userRequest)
+	if err != nil {
+		l.Error("failed to create user", zap.Error(err), zap.String("email", email))
+		return nil, nil, nil, fmt.Errorf("failed to create user: %w", err)
+	}
+
+	l.Info("user created successfully",
+		zap.String("username", username),
+		zap.String("email", email),
+	)
+
+	// Add user to the default group if available
+	if u.client.DefaultGroupName != "" {
+		_, err = u.client.AddUserToGroup(ctx, u.client.DefaultGroupName, username)
+		if err != nil {
+			l.Warn("failed to add user to default group",
+				zap.String("group", u.client.DefaultGroupName),
+				zap.String("username", username),
+				zap.Error(err),
+			)
+			// Don't fail the whole operation if just the group assignment fails
+		} else {
+			l.Info("added user to default group",
+				zap.String("group", u.client.DefaultGroupName),
+				zap.String("username", username),
+			)
+		}
+	}
+
+	// Create a resource from the new user
+	resource, err := userResource(*user)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create resource for new user: %w", err)
+	}
+
+	// Return success result with the new user resource
+	successResult := &v2.CreateAccountResponse_SuccessResult{
+		Resource: resource,
+	}
+
+	return successResult, plaintextData, nil, nil
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -149,7 +149,7 @@ func (u *userBuilder) CreateAccount(
 	l := ctxzap.Extract(ctx)
 
 	// Extract account information from the profile
-	profile := accountInfo.Profile.AsMap()
+	profile := accountInfo.GetProfile().AsMap()
 
 	// Get required fields
 	email, ok := profile["email"].(string)


### PR DESCRIPTION
## Summary
- Added user provisioning capability to the Jira Datacenter connector
- Implemented CreateUser client method and AccountManager interface
- Added automatic default group assignment for new users
- Updated connector capabilities to indicate user provisioning support

## Test plan
- Verify user creation through the connector
- Confirm new users are assigned to the default group automatically
- Test with various input combinations to ensure proper field validation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for creating new user accounts in Jira Datacenter through the connector, including random password generation and group assignment.
  - Enhanced the connector metadata to display required fields for account creation (email, first name, last name) with user-friendly descriptions and placeholders.

- **Bug Fixes**
  - Comprehensive error handling for missing fields, password generation failures, user creation issues, and resource creation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

I tested account creation, entitlement provision as part of account creation and revoke, it all worked.

![image](https://github.com/user-attachments/assets/7200cba6-0e02-4bd9-95f4-fa0aea3e5bb8)
blob:https://conductorone.atlassian.net/329ff17c-e264-485b-b271-f1e43a244d2d#media-blob-url=true&id=ee81efde-9418-4c0a-a55b-0bf6c0fad0d4&contextId=24647&collection=