### PR TITLE
[BB-801] add grant already exists for groups

### DIFF
--- a/pkg/client/internal_test.go
+++ b/pkg/client/internal_test.go
@@ -258,9 +258,9 @@ func TestClientAddUserToGroup(t *testing.T) {
 	userName, err := client.GetUserName(ctx, "JIRAUSER10103")
 	assert.Nil(t, err)
 
-	statusCode, err := client.AddUserToGroup(ctx, "jira-administrators", userName)
+	success, err := client.AddUserToGroup(ctx, "jira-administrators", userName)
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusCreated, statusCode)
+	assert.True(t, success)
 }
 
 func TestClientRemoveUserFromGroup(t *testing.T) {
@@ -272,9 +272,9 @@ func TestClientRemoveUserFromGroup(t *testing.T) {
 	userName, err := client.GetUserName(ctx, "JIRAUSER10103")
 	assert.Nil(t, err)
 
-	statusCode, err := client.RemoveUserFromGroup(ctx, "jira-administrators", userName)
+	success, err := client.RemoveUserFromGroup(ctx, "jira-administrators", userName)
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, statusCode)
+	assert.True(t, success)
 }
 
 func TestClientAddProjectRoleActorsToRoleWithGroup(t *testing.T) {

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -73,16 +73,27 @@ type Actors struct {
 }
 
 type UsersAPIData struct {
-	Self         string     `json:"self,omitempty"`
-	Key          string     `json:"key,omitempty"`
-	Name         string     `json:"name,omitempty"`
-	EmailAddress string     `json:"emailAddress,omitempty"`
-	AvatarUrls   AvatarUrls `json:"avatarUrls,omitempty"`
-	DisplayName  string     `json:"displayName,omitempty"`
-	Active       bool       `json:"active,omitempty"`
-	Deleted      bool       `json:"deleted,omitempty"`
-	TimeZone     string     `json:"timeZone,omitempty"`
-	Locale       string     `json:"locale,omitempty"`
+	Self         string          `json:"self,omitempty"`
+	Key          string          `json:"key,omitempty"`
+	Name         string          `json:"name,omitempty"`
+	EmailAddress string          `json:"emailAddress,omitempty"`
+	AvatarUrls   AvatarUrls      `json:"avatarUrls,omitempty"`
+	DisplayName  string          `json:"displayName,omitempty"`
+	Active       bool            `json:"active,omitempty"`
+	Deleted      bool            `json:"deleted,omitempty"`
+	TimeZone     string          `json:"timeZone,omitempty"`
+	Locale       string          `json:"locale,omitempty"`
+	Groups       *UserGroupsList `json:"groups,omitempty"`
+}
+
+type UserGroupsList struct {
+	Size  int         `json:"size,omitempty"`
+	Items []UserGroup `json:"items,omitempty"`
+}
+
+type UserGroup struct {
+	Name string `json:"name,omitempty"`
+	Self string `json:"self,omitempty"`
 }
 
 type GroupRolesAPIData struct {


### PR DESCRIPTION
# Pull Request

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the Connector in any way?

* [x ] Yes (backward compatible)
* [ ] No (breaking changes)

#### Useful links:

- [https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines](Baton SDK coding guidelines)
- [https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md](New contributor guide)

## Issue Linking
<!--
    KEYWORD #ISSUE-NUMBER
    [closes|fixes|resolves] #
-->

## What's new?
- Adds grant already exists for groups


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when adding or removing users from groups by returning clear success indicators.
  - Avoided redundant operations by checking user group membership status before changes.
- **New Features**
  - Added ability to fetch user details by key, including group membership information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->