### PR TITLE
fix: mark access-token as isSecret in config_schema

### DIFF
--- a/cmd/baton-jira-datacenter/config.go
+++ b/cmd/baton-jira-datacenter/config.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	instanceURLField = field.StringField("instance-url", field.WithRequired(true), field.WithDescription(`The URL that Jira is hosted at. Example: "https://localhost:8080"`))
-	accessTokenField = field.StringField("access-token", field.WithRequired(true), field.WithDescription("The Jira personal access token to authenticate with."))
+	accessTokenField = field.StringField("access-token", field.WithRequired(true), field.WithDescription("The Jira personal access token to authenticate with."), field.WithIsSecret(true))
 	projectKeysField = field.StringSliceField("project-keys", field.WithDescription("Limit external ticket schemas to any of the provided project keys"))
 	defaultGroupName = field.StringField("default-group-name", field.WithDefaultValue("jira-software-users"), field.WithDescription("The default group name for new users"))
 )


### PR DESCRIPTION
BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

The credential field(s) are defined in Go via the baton `field` package, which is the source the config schema is derived from (no separate generated config_schema.json is committed in this repo), so adding `field.WithIsSecret(true)` to the field definition is the complete fix.

<!-- stargate: connector-secret-audit-phase11 -->